### PR TITLE
fix saving nuclides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xpypact"
-version = "0.5.5a0"
+version = "0.5.5"
 description = "\"Python workflow framework for FISPACT.\""
 authors = ["dvp <dmitri_portnov@yahoo.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xpypact"
-version = "0.5.4"
+version = "0.5.5a0"
 description = "\"Python workflow framework for FISPACT.\""
 authors = ["dvp <dmitri_portnov@yahoo.com>"]
 license = "MIT"

--- a/src/xpypact/dao/api.py
+++ b/src/xpypact/dao/api.py
@@ -40,13 +40,20 @@ class DataAccessInterface(ABC):
         """Drop our DB objects."""
 
     @abstractmethod
-    def save(self, inventory: Inventory, material_id: int = 1, case_id: str = "") -> None:
+    def save(self, inventory: Inventory, material_id: int = 1, case_id: int = 1) -> None:
         """Save xpypact inventory to database.
 
         Args:
             inventory: what to save
             material_id: additional key to distinguish multiple FISPACT runs
             case_id: second additional key
+        """
+
+    @abstractmethod
+    def on_save_complete(self) -> None:
+        """Execute on saving all the innventories.
+
+        Save information that is to be saved after multithreading processing.
         """
 
     @abstractmethod

--- a/src/xpypact/dao/duckdb/create_schema.sql
+++ b/src/xpypact/dao/duckdb/create_schema.sql
@@ -39,13 +39,14 @@ create table timestep (
 
 
 create table nuclide (
+    zai uinteger not null check (10010 <= zai) primary key,
     element varchar(2) not null,
     mass_number usmallint not null check (0 < mass_number),
     state varchar(1) not null,
-    zai uinteger not null check (10010 <= zai) unique,
-    half_life real not null check (0 <= half_life),
-    primary key (element, mass_number, state)
+    half_life real not null check (0 <= half_life)
 );
+
+create unique index nuclide_ems on nuclide (element, mass_number, state);
 
 create table timestep_nuclide (
     material_id uinteger not null,
@@ -70,8 +71,7 @@ create table timestep_nuclide (
     inhalation real not null,
 
     primary key (material_id, case_id, time_step_number, zai),
-    foreign key (material_id, case_id, time_step_number) references timestep (material_id, case_id, time_step_number),
-    foreign key (zai) references nuclide (zai)
+    foreign key (material_id, case_id, time_step_number) references timestep (material_id, case_id, time_step_number)
 );
 
 create table gbins (

--- a/src/xpypact/nuclide.py
+++ b/src/xpypact/nuclide.py
@@ -58,7 +58,9 @@ class Nuclide(ms.Struct):  # pylint: disable=too-many-instance-attributes
 
     def __post_init__(self) -> None:
         """Make the values consistent in data from old FISPACT."""
-        if self.zai == 0 or self.atoms == FLOAT_ZERO and self.grams > FLOAT_ZERO:
+        if (
+            self.zai == 0 or self.atoms == FLOAT_ZERO and self.grams > FLOAT_ZERO
+        ):  # pragma: no cover
             _z = z(self.element)
             if self.zai == 0:
                 self.zai = _z * 10000 + self.isotope * 10

--- a/tests/test_nuclide.py
+++ b/tests/test_nuclide.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from xpypact.nuclide import Nuclide
+
+
+@pytest.mark.parametrize(
+    "a,b,eq,order",
+    [
+        (("H", 1, "", 10010), ("H", 1, "", 10010), True, False),
+        (("H", 1, "", 10010), ("H", 2, "", 10020), False, True),
+    ],
+)
+def test_equality_and_comparison(
+    a: tuple[str, int, str, int],
+    b: tuple[str, int, str, int],
+    eq: bool,  # noqa: FBT001
+    order: bool,  # noqa: FBT001
+) -> None:
+    _a = Nuclide(*a).info
+    _b = Nuclide(*b).info
+    assert eq == (_a == _b)
+    assert order == (_a < _b)


### PR DESCRIPTION
When saving nuclides from a number of Inventories using multiprocessing sometimes commits fail on violation of unique constraint (zai). We'd better to save the nuclides after multiproccessing is complete. Besides, this will be just one saving operation instead of thousands.